### PR TITLE
Mark Tlb2H as dependent on Lz4lib in solution

### DIFF
--- a/Source/DvEngine.sln
+++ b/Source/DvEngine.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Database Generator", "Database Generator", "{C595CD5F-42AE-42E8-802B-B9505D6A6B61}"
 EndProject
@@ -37,6 +37,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "File2Inc", "MiscUtils\File2Inc\File2Inc.vcxproj", "{B705E0BA-56FF-4BA7-847B-0FE0DA2DBA8E}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Tlb2H", "Database\Tlb2H\Tlb2H.vcxproj", "{E9957503-B1E0-4E1B-A027-6E304E644CF3}"
+	ProjectSection(ProjectDependencies) = postProject
+		{BF4BA8BE-12DC-4D9F-9939-1505A451E293} = {BF4BA8BE-12DC-4D9F-9939-1505A451E293}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DbMerge", "Database\DbMerge\DbMerge.vcxproj", "{64249CFD-06D5-4A5A-813F-0D467485838C}"
 EndProject


### PR DESCRIPTION
Increases build reliability of projects using Deviare projects in their
solutions.

Otherwise, it's a bit of luck that Lz4lib is built before Tlb2H when
building the solution.